### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/quay.yaml
+++ b/.github/workflows/quay.yaml
@@ -19,7 +19,7 @@ jobs:
         echo ::set-output name=FULL_VERSION::${VERSION}
         echo ::set-output name=MINOR_VERSION::${VERSION%.*}
     - name: Publish My Image to Quay
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jkupferer/python-kopf-s2i
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore